### PR TITLE
Fix lock expiration and seconds remaining when lock passes 24 hours old

### DIFF
--- a/locking/models.py
+++ b/locking/models.py
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from django.db import models
 from django.conf import settings
@@ -79,7 +79,7 @@ class Lock(models.Model):
 		Works by calculating if the last lock (self.locked_at) has timed out or not.
 		"""
 		if isinstance(self.locked_at, datetime):
-			if (datetime.today() - self.locked_at).seconds < settings.LOCKING['time_until_expiration']:
+			if (datetime.today() - self.locked_at) < timedelta(seconds=settings.LOCKING['time_until_expiration']):
 				return True
 			else:
 				return False
@@ -97,7 +97,8 @@ class Lock(models.Model):
 		If you want to extend a lock beyond its current expiry date, initiate a new
 		lock using the ``lock_for`` method.
 		"""
-		return settings.LOCKING['time_until_expiration'] - (datetime.today() - self.locked_at).seconds
+		diff = timedelta(settings.LOCKING['time_until_expiration']) - (datetime.today() - self.locked_at)
+		return (diff.days * 24 * 60 * 60) + diff.seconds
 	
 	def lock_for(self, user, hard_lock=True):
 		"""

--- a/locking/tests/tests.py
+++ b/locking/tests/tests.py
@@ -71,7 +71,39 @@ class AppTestCase(TestCase):
         self.assertTrue(self.story.is_locked)
         self.story._locked_at = datetime.today() - timedelta(minutes=LOCK_TIMEOUT+1)
         self.assertFalse(self.story.is_locked)
-    
+
+    def test_lock_expiration_day(self):
+        self.story.lock_for(self.user)
+        self.assertTrue(self.story.is_locked)
+        self.story._locked_at = datetime.today() - timedelta(days=1, seconds=1)
+        self.assertFalse(self.story.is_locked)
+
+    def test_lock_seconds_remaining(self):
+        self.story.lock_for(self.user)
+        expected = LOCK_TIMEOUT
+        self.assertTrue(self.story.lock_seconds_remaining <= expected + 1 and
+                        self.story.lock_seconds_remaining >= expected - 1,
+                        "%d not close to %d" % (
+                            self.story.lock_seconds_remaining, expected))
+
+    def test_lock_seconds_remaining_half_timeout(self):
+        self.story.lock_for(self.user)
+        self.story._locked_at -= timedelta(seconds=(LOCK_TIMEOUT / 2))
+        expected = LOCK_TIMEOUT / 2
+        self.assertTrue(self.story.lock_seconds_remaining <= expected + 1 and
+                        self.story.lock_seconds_remaining >= expected - 1,
+                        "%d not close to %d" % (
+                            self.story.lock_seconds_remaining, expected))
+
+    def test_lock_seconds_remaining_day(self):
+        self.story.lock_for(self.user)
+        self.story._locked_at -= timedelta(days=1)
+        expected = LOCK_TIMEOUT - (24 * 60 * 60)
+        self.assertTrue(self.story.lock_seconds_remaining <= expected + 1 and
+                        self.story.lock_seconds_remaining >= expected - 1,
+                        "%d not close to %d" % (
+                            self.story.lock_seconds_remaining, expected))
+
     def test_lock_applies_to(self):
         self.story.lock_for(self.alt_user)
         applies = self.story.lock_applies_to(self.user)


### PR DESCRIPTION
datetime.timedelta() normalizes times to days and seconds within a day.  For example, if a time delta is 86401 seconds, then td.seconds is 1.  The way to get absolute seconds is to mutliply td.days by seconds in a day, and then add in seconds.  In python 2.7, there is a [timedelta.total_seconds()](http://docs.python.org/release/2.7/library/datetime.html#datetime.timedelta.total_seconds) call that does this math for you.

Because is_locked and lock_seconds_remaining only looked at the seconds, they behave strangely around day barriers.

I've tested this change against the 0.3 codebase, which we're using, but not 1.0.  The tests should work, (and some fail without the change), but someone should try it.
