### PR TITLE
Bug fix for django 1.4.1 admin - issue with get_form and adding new records

### DIFF
--- a/locking/admin.py
+++ b/locking/admin.py
@@ -23,7 +23,7 @@ class LockableAdmin(admin.ModelAdmin):
         )
         css = {"all": (_s.STATIC_URL + 'locking/css/locking.css',)}
 
-    def get_form(self, request, obj, *args, **kwargs):
+    def get_form(self, request, obj=None, *args, **kwargs):
         form = super(LockableAdmin, self).get_form(request, *args, **kwargs)
         form.request = request
         form.obj = obj


### PR DESCRIPTION
I was having an issue in django 1.4.1 (presumably also 1.4) when options.py calls get_form when adding a new record, it expects only the `self` and `request` parameters to be required. I defaulted the `obj` parameter to `None` to resolve this.
