### PR TITLE
Added the obj argument in the get_form super call

### DIFF
--- a/locking/admin.py
+++ b/locking/admin.py
@@ -24,7 +24,8 @@ class LockableAdmin(admin.ModelAdmin):
         css = {"all": (_s.STATIC_URL + 'locking/css/locking.css',)}
 
     def get_form(self, request, obj=None, *args, **kwargs):
-        form = super(LockableAdmin, self).get_form(request, *args, **kwargs)
+        form = super(LockableAdmin, self).get_form(request, obj, *args, 
+                                                   **kwargs)
         form.request = request
         form.obj = obj
         return form

--- a/locking/admin.py
+++ b/locking/admin.py
@@ -16,7 +16,7 @@ class LockableAdmin(admin.ModelAdmin):
 
     class Media:
         js = (
-            'http://ajax.googleapis.com/ajax/libs/jquery/1.4.2/jquery.min.js', 
+            '//ajax.googleapis.com/ajax/libs/jquery/1.4.2/jquery.min.js', 
             _s.STATIC_URL + 'locking/js/jquery.url.packed.js',
             _s.ADMIN_URL + "ajax/variables.js",
             _s.STATIC_URL + "locking/js/admin.locking.js?v=1"


### PR DESCRIPTION
The get_form method was calling its super method (defined in the ModelAdmin) but wasn't passing along the obj parameter, causing unexpected behavior.
