### PR TITLE
updated import for django.conf.urls.defaults deprecation

### DIFF
--- a/locking/managers.py
+++ b/locking/managers.py
@@ -15,11 +15,11 @@ def point_of_timeout():
     return datetime.datetime.now() - delta
 
 class LockedManager(Manager):
-    def get_query_set(self):
+    def get_queryset(self):
         timeout = point_of_timeout()
-        return super(LockedManager, self).get_query_set().filter(_locked_at__gt=timeout, _locked_at__isnull=False)
+        return super(LockedManager, self).get_queryset().filter(_locked_at__gt=timeout, _locked_at__isnull=False)
 
 class UnlockedManager(Manager):
-    def get_query_set(self):
+    def get_queryset(self):
         timeout = point_of_timeout()
-        return super(UnlockedManager, self).get_query_set().filter(Q(_locked_at__lte=timeout) | Q(_locked_at__isnull=True))
+        return super(UnlockedManager, self).get_queryset().filter(Q(_locked_at__lte=timeout) | Q(_locked_at__isnull=True))

--- a/locking/urls.py
+++ b/locking/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import *
+from django.conf.urls import *
 
 urlpatterns = patterns('locking.views',
     # verwijst naar een ajax-view voor het lockingmechanisme


### PR DESCRIPTION
django.conf.urls.defaults removed in django 1.6 - now django.conf.urls

see https://docs.djangoproject.com/en/dev/internals/deprecation/#id3
